### PR TITLE
Suporte às notificações das Assinaturas

### DIFF
--- a/src/Artistas/PagSeguroClient.php
+++ b/src/Artistas/PagSeguroClient.php
@@ -196,12 +196,18 @@ class PagSeguroClient extends PagSeguroConfig
      *
      * @return \SimpleXMLElement
      */
-    public function notification($notificationCode)
+    public function notification($notificationCode, $notificationType = 'transaction')
     {
-        return $this->sendTransaction([
-          'email' => $this->email,
-          'token' => $this->token,
-        ], $this->url['notifications'].$notificationCode, false);
+        if($notificationType == 'transaction')
+            return $this->sendTransaction([
+              'email' => $this->email,
+              'token' => $this->token,
+            ], $this->url['notifications'].$notificationCode, false);
+        else if($notificationType == 'preApproval')
+            return $this->sendTransaction([
+              'email' => $this->email,
+              'token' => $this->token,
+            ], $this->url['preApprovalNotifications'].$notificationCode, false);
     }
 
     /**

--- a/src/Artistas/PagSeguroClient.php
+++ b/src/Artistas/PagSeguroClient.php
@@ -203,7 +203,7 @@ class PagSeguroClient extends PagSeguroConfig
               'email' => $this->email,
               'token' => $this->token,
             ], $this->url['notifications'].$notificationCode, false);
-        else if ($notificationType == 'preApproval') {
+        } elseif ($notificationType == 'preApproval') {
             return $this->sendTransaction([
               'email' => $this->email,
               'token' => $this->token,

--- a/src/Artistas/PagSeguroClient.php
+++ b/src/Artistas/PagSeguroClient.php
@@ -198,16 +198,17 @@ class PagSeguroClient extends PagSeguroConfig
      */
     public function notification($notificationCode, $notificationType = 'transaction')
     {
-        if($notificationType == 'transaction')
+        if ($notificationType == 'transaction') {
             return $this->sendTransaction([
               'email' => $this->email,
               'token' => $this->token,
             ], $this->url['notifications'].$notificationCode, false);
-        else if($notificationType == 'preApproval')
+        elseif ($notificationType == 'preApproval') {
             return $this->sendTransaction([
               'email' => $this->email,
               'token' => $this->token,
             ], $this->url['preApprovalNotifications'].$notificationCode, false);
+        }
     }
 
     /**

--- a/src/Artistas/PagSeguroClient.php
+++ b/src/Artistas/PagSeguroClient.php
@@ -190,7 +190,7 @@ class PagSeguroClient extends PagSeguroConfig
     }
 
     /**
-     * Retorna a transação da notoficação.
+     * Retorna a transação da notificação.
      *
      * @param string $notificationCode
      *

--- a/src/Artistas/PagSeguroClient.php
+++ b/src/Artistas/PagSeguroClient.php
@@ -203,7 +203,7 @@ class PagSeguroClient extends PagSeguroConfig
               'email' => $this->email,
               'token' => $this->token,
             ], $this->url['notifications'].$notificationCode, false);
-        elseif ($notificationType == 'preApproval') {
+        else if ($notificationType == 'preApproval') {
             return $this->sendTransaction([
               'email' => $this->email,
               'token' => $this->token,

--- a/src/Artistas/PagSeguroConfig.php
+++ b/src/Artistas/PagSeguroConfig.php
@@ -90,6 +90,7 @@ class PagSeguroConfig
             'preApprovalRequest'            => 'https://ws.'.$sandbox.'pagseguro.uol.com.br/v2/pre-approvals/request',
             'preApproval'                   => 'https://ws.'.$sandbox.'pagseguro.uol.com.br/pre-approvals',
             'preApprovalCancel'             => 'https://ws.'.$sandbox.'pagseguro.uol.com.br/v2/pre-approvals/cancel/',
+            'preApprovalNotifications'      => 'https://ws.'.$sandbox.'pagseguro.uol.com.br/v2/pre-approvals/notifications/',
             'session'                       => 'https://ws.'.$sandbox.'pagseguro.uol.com.br/v2/sessions',
             'transactions'                  => 'https://ws.'.$sandbox.'pagseguro.uol.com.br/v2/transactions',
             'notifications'                 => 'https://ws.'.$sandbox.'pagseguro.uol.com.br/v3/transactions/notifications/',


### PR DESCRIPTION
Esse PR corrige o problema das notificações de Assinatura e evita mudanças nos códigos legados usando o método `PagSeguro::notification(...) `