### PR TITLE
Implementação da listagem de ordens de pagamento

### DIFF
--- a/src/Artistas/PagSeguroClient.php
+++ b/src/Artistas/PagSeguroClient.php
@@ -69,7 +69,7 @@ class PagSeguroClient extends PagSeguroConfig
         if ($method == 'GET') {
             $parameters = null;
         }
-        
+
         $result = $this->executeCurl($parameters, $url, ['Accept: application/vnd.pagseguro.com.br.v3+json;charset=ISO-8859-1', 'Content-Type: application/json; charset=UTF-8']);
 
         return $this->formatResultJson($result);

--- a/src/Artistas/PagSeguroClient.php
+++ b/src/Artistas/PagSeguroClient.php
@@ -66,6 +66,10 @@ class PagSeguroClient extends PagSeguroConfig
         });
         $parameters = json_encode($parameters);
 
+        if ($method == 'GET') {
+            $parameters = null;
+        }
+        
         $result = $this->executeCurl($parameters, $url, ['Accept: application/vnd.pagseguro.com.br.v3+json;charset=ISO-8859-1', 'Content-Type: application/json; charset=UTF-8']);
 
         return $this->formatResultJson($result);

--- a/src/Artistas/PagSeguroRecorrente.php
+++ b/src/Artistas/PagSeguroRecorrente.php
@@ -427,4 +427,16 @@ class PagSeguroRecorrente extends PagSeguroClient
             'token' => $this->token,
         ], $this->url['preApprovalCancel'].$preApprovalCode, false);
     }
+    
+    /**
+     * Lista as ordens de pagamento de um pagamento recorrente.
+     *
+     * @param string $preApprovalCode
+     *
+     * @return \SimpleXMLElement
+     */
+    public function paymentOrders($preApprovalCode)
+    {
+        return $this->sendJsonTransaction([], $this->url['preApproval'].'/'. $preApprovalCode . '/payment-orders', 'GET');
+    }
 }

--- a/src/Artistas/PagSeguroRecorrente.php
+++ b/src/Artistas/PagSeguroRecorrente.php
@@ -427,7 +427,7 @@ class PagSeguroRecorrente extends PagSeguroClient
             'token' => $this->token,
         ], $this->url['preApprovalCancel'].$preApprovalCode, false);
     }
-    
+
     /**
      * Lista as ordens de pagamento de um pagamento recorrente.
      *

--- a/src/Artistas/PagSeguroRecorrente.php
+++ b/src/Artistas/PagSeguroRecorrente.php
@@ -437,6 +437,6 @@ class PagSeguroRecorrente extends PagSeguroClient
      */
     public function paymentOrders($preApprovalCode)
     {
-        return $this->sendJsonTransaction([], $this->url['preApproval'].'/'. $preApprovalCode . '/payment-orders', 'GET');
+        return $this->sendJsonTransaction([], $this->url['preApproval'].'/'.$preApprovalCode.'/payment-orders', 'GET');
     }
 }


### PR DESCRIPTION
Implementa o método da API do PagSeguro referente a listagem de Ordens
de Pagamento de um Pagamento Recorrente

Exemplo de uso:

`PagSeguroRecorrente::paymentOrders($preApprovalCode)`

Como é uma consulta via GET e o `sendJsonTransaction() ` já possui a setagem automática de credenciais o `$parameter` passado foi uma array vazia e logo depois foi setada para null para satisfazer a condição do `executeCurl()`, de que se o $parameter for null o método não vira POST