### PR TITLE
Suporte à alteração do Método de Pagamento de um Pagamento Recorrente

### DIFF
--- a/src/Artistas/PagSeguroClient.php
+++ b/src/Artistas/PagSeguroClient.php
@@ -30,12 +30,12 @@ class PagSeguroClient extends PagSeguroConfig
         }
         $parameters = rtrim($data, '&');
 
-        $method = "POST";
+        $method = 'POST';
         
         if (!$post) {
             $url .= '?'.$parameters;
             $parameters = null;
-            $method = "GET";
+            $method = 'GET';
         }
 
         $result = $this->executeCurl($parameters, $url, ['Content-Type: application/x-www-form-urlencoded; charset=ISO-8859-1'], $method);
@@ -93,10 +93,10 @@ class PagSeguroClient extends PagSeguroConfig
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
 
-        if ($method == "POST") {
+        if ($method == 'POST') {
             curl_setopt($curl, CURLOPT_POST, true);
-        } else if ($method == "PUT") {
-            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PUT");
+        } else if ($method == 'PUT') {
+            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
         }
 
         if ($parameters !== null) {

--- a/src/Artistas/PagSeguroClient.php
+++ b/src/Artistas/PagSeguroClient.php
@@ -30,12 +30,16 @@ class PagSeguroClient extends PagSeguroConfig
         }
         $parameters = rtrim($data, '&');
 
+        $method = "POST";
+        
         if (!$post) {
             $url .= '?'.$parameters;
             $parameters = null;
+            $method = "GET";
         }
 
-        $result = $this->executeCurl($parameters, $url, ['Content-Type: application/x-www-form-urlencoded; charset=ISO-8859-1']);
+
+        $result = $this->executeCurl($parameters, $url, ['Content-Type: application/x-www-form-urlencoded; charset=ISO-8859-1'], $method);
 
         return $this->formatResult($result);
     }
@@ -70,7 +74,9 @@ class PagSeguroClient extends PagSeguroConfig
             $parameters = null;
         }
 
-        $result = $this->executeCurl($parameters, $url, ['Accept: application/vnd.pagseguro.com.br.v3+json;charset=ISO-8859-1', 'Content-Type: application/json; charset=UTF-8']);
+        $result = $this->executeCurl($parameters, $url, ['Accept: application/vnd.pagseguro.com.br.v3+json;charset=ISO-8859-1', 'Content-Type: application/json; charset=UTF-8'], $method);
+
+        \Log::alert($result);
 
         return $this->formatResultJson($result);
     }
@@ -84,14 +90,22 @@ class PagSeguroClient extends PagSeguroConfig
      *
      * @return \SimpleXMLElement
      */
-    private function executeCurl($parameters, $url, array $headers)
+    private function executeCurl($parameters, $url, array $headers, $method)
     {
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
 
-        if ($parameters !== null) {
+
+
+
+        if ($method == "POST") {
             curl_setopt($curl, CURLOPT_POST, true);
+        } else if ($method == "PUT") {
+            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PUT");
+        }
+
+        if ($parameters !== null) {
             curl_setopt($curl, CURLOPT_POSTFIELDS, $parameters);
         }
 

--- a/src/Artistas/PagSeguroClient.php
+++ b/src/Artistas/PagSeguroClient.php
@@ -38,7 +38,6 @@ class PagSeguroClient extends PagSeguroConfig
             $method = "GET";
         }
 
-
         $result = $this->executeCurl($parameters, $url, ['Content-Type: application/x-www-form-urlencoded; charset=ISO-8859-1'], $method);
 
         return $this->formatResult($result);
@@ -76,8 +75,6 @@ class PagSeguroClient extends PagSeguroConfig
 
         $result = $this->executeCurl($parameters, $url, ['Accept: application/vnd.pagseguro.com.br.v3+json;charset=ISO-8859-1', 'Content-Type: application/json; charset=UTF-8'], $method);
 
-        \Log::alert($result);
-
         return $this->formatResultJson($result);
     }
 
@@ -95,9 +92,6 @@ class PagSeguroClient extends PagSeguroConfig
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-
-
-
 
         if ($method == "POST") {
             curl_setopt($curl, CURLOPT_POST, true);

--- a/src/Artistas/PagSeguroClient.php
+++ b/src/Artistas/PagSeguroClient.php
@@ -31,7 +31,7 @@ class PagSeguroClient extends PagSeguroConfig
         $parameters = rtrim($data, '&');
 
         $method = 'POST';
-        
+
         if (!$post) {
             $url .= '?'.$parameters;
             $parameters = null;
@@ -95,7 +95,7 @@ class PagSeguroClient extends PagSeguroConfig
 
         if ($method == 'POST') {
             curl_setopt($curl, CURLOPT_POST, true);
-        } else if ($method == 'PUT') {
+        } elseif ($method == 'PUT') {
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
         }
 

--- a/src/Artistas/PagSeguroRecorrente.php
+++ b/src/Artistas/PagSeguroRecorrente.php
@@ -353,6 +353,7 @@ class PagSeguroRecorrente extends PagSeguroClient
     }
 
     /**
+     * Altera o método de pagamento de um pagamento recorrente.
      *
      * @param array $paymentSettings
      *

--- a/src/Artistas/PagSeguroRecorrente.php
+++ b/src/Artistas/PagSeguroRecorrente.php
@@ -368,7 +368,7 @@ class PagSeguroRecorrente extends PagSeguroClient
 
         $data = $this->formatPreApprovalPaymentMethodData($paymentSettings);
 
-        return (string) $this->sendJsonTransaction($data, $this->url['preApproval'] . '/' . $this->plan . '/payment-method', 'PUT');
+        return (string) $this->sendJsonTransaction($data, $this->url['preApproval'].'/'.$this->plan.'/payment-method', 'PUT');
     }
 
     /**

--- a/src/Artistas/PagSeguroRecorrente.php
+++ b/src/Artistas/PagSeguroRecorrente.php
@@ -453,7 +453,6 @@ class PagSeguroRecorrente extends PagSeguroClient
         return $data;
     }
 
-
     /**
      * Formata os dados para enviar a alteração do método de pagamento.
      *

--- a/src/Artistas/PagSeguroRecorrente.php
+++ b/src/Artistas/PagSeguroRecorrente.php
@@ -53,7 +53,6 @@ class PagSeguroRecorrente extends PagSeguroClient
      */
     private $type;
 
-
     /**
      * Define os dados do plano.
      *


### PR DESCRIPTION
Essas alterações permitem realizar a alteração de método de pagamento.  

Como o PagSeguro exige que o method da request seja PUT tive que fazer algumas alterações no executeCurl, sendJsonTransaction e sendTransaction para evitar conflitos com as versões anteriores.

O método utilizado para realizar essa ação é o `PagSeguroRecorrente::sendPreApprovalPaymentMethod(array)`

Da mesma forma que é feita a adesão a um plano, esse método também precisa de ter alguns dados obrigatórios. Portanto assim que der eu crio um exemplo no wiki

------

Observações: Por enquanto só existe o tipo CREDITCARD, mas para evitar futuros problemas criei o método setType genérico