### PR TITLE
método para consultar uma adesão através do código de pre-approval

### DIFF
--- a/src/Artistas/PagSeguroRecorrente.php
+++ b/src/Artistas/PagSeguroRecorrente.php
@@ -542,4 +542,16 @@ class PagSeguroRecorrente extends PagSeguroClient
     {
         return $this->sendJsonTransaction([], $this->url['preApproval'].'/'.$preApprovalCode.'/payment-orders', 'GET');
     }
+
+        /**
+     * Consulta um pagamento recorrente.
+     *
+     * @param string $preApprovalCode
+     *
+     * @return \SimpleXMLElement
+     */
+    public function showPreApproval($preApprovalCode)
+    {
+        return $this->sendJsonTransaction([], $this->url['preApproval'].'/'.$preApprovalCode, 'GET');
+    }
 }


### PR DESCRIPTION
No PagseguroRecorrente.php apenas há um método para consultar as "payment orders", e não há nenhum método que consulta a própria adesão. Com esse método é possível consultar a adesão. 
