### PR TITLE
Correção de erro "strict" no Chrome

### DIFF
--- a/src/Artistas/routes.php
+++ b/src/Artistas/routes.php
@@ -5,5 +5,5 @@ Route::get('/pagseguro/session', function () {
 });
 
 Route::get('/pagseguro/javascript', function () {
-    return file_get_contents(\PagSeguro::getUrl()['javascript']);
+    return response()->make(file_get_contents(\PagSeguro::getUrl()['javascript']), '200')->header('Content-Type', 'text/javascript');
 });


### PR DESCRIPTION
Refused to execute script from '' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.