### PR TITLE
Adiciona o método sendRetentative() que permite a retentativa de uma …

### DIFF
--- a/src/Artistas/PagSeguroRecorrente.php
+++ b/src/Artistas/PagSeguroRecorrente.php
@@ -627,4 +627,16 @@ class PagSeguroRecorrente extends PagSeguroClient
 
         return $data;
     }
+    
+    /**
+     * Retentativa de pagamento - Permite a retentativa de uma cobrança não paga ou não processada. 
+     *
+     * @param string $orderCode
+     *
+     * @return \SimpleXMLElement
+     */
+    public function sendRetentative(string $orderCode)
+    {
+        return $this->sendJsonTransaction([], $this->url['preApproval'] . '/' . $this->preApprovalCode . '/payment-orders/' . $orderCode . '/payment');
+    }
 }


### PR DESCRIPTION
Adiciona o método sendRetentative() que permite a retentativa de uma cobrança não paga ou não processada.
Para aplicar o método o usuário precisa setar o Plano com o (setPlan) e enviar o método sendDiscount com o número da Order (mensalidade).
A tentativa de cobrança será realizada somente se a ordem de pagamento da adesão estiver com o status “Não Pago "

Exemplo de código final:

PagSeguroRecorrente::setPreApprovalCode('51347072DADABC5334B0FFB86A9DF904')
->sendRetentative('E3A5AD39BDF84136B7563C0498F4AB1C');