### PR TITLE
Adicionado suporte para nova API de boletos do pagseguro

### DIFF
--- a/src/Artistas/PagSeguroBoleto.php
+++ b/src/Artistas/PagSeguroBoleto.php
@@ -1,0 +1,301 @@
+<?php
+
+namespace Artistas\PagSeguro;
+
+class PagSeguroBoleto extends PagSeguroClient
+{
+    /**
+     * Identificador da compra.
+     *
+     * @var string
+     */
+    private $reference;
+
+    /**
+     * Data de vencimento do boleto.
+     *
+     * @var string
+     */
+    private $firstDueDate;
+
+    /**
+     * Quantidade de boletos gerados.
+     *
+     * @var string
+     */
+    private $numberOfPayments;
+
+    /**
+     * Valor da compra.
+     *
+     * @var string
+     */
+    private $amount;
+
+    /**
+     * Instruções do boleto.
+     *
+     * @var string
+     */
+    private $instructions;
+
+    /**
+     * Descrição do item do boleto.
+     *
+     * @var string
+     */
+    private $description;
+
+    /**
+     * Informações do comprador.
+     *
+     * @var array
+     */
+    private $custumer = [];
+
+    /**
+     * Define os dados do comprador.
+     *
+     * @param array $customerInfo
+     *
+     * @return PagSeguroBoleto
+     *
+     * @throws \Artistas\PagSeguro\PagSeguroException
+     */
+    public function setCustomerInfo(array $customerInfo)
+    {
+        $customerEmail = $this->sanitize($customerInfo, 'email');
+
+        $customerPhone = $this->sanitizeNumber($customerInfo, 'phone');
+
+        $this->custumer['customer'] = [
+            'name'      => $this->sanitize($customerInfo, 'name'),
+            'email'     => $customerEmail
+        ];
+
+        $this->custumer['customer']['document'] = [
+            'type'   => !empty($this->sanitizeNumber($customerInfo, 'customerCPF')) ?  'CPF' : 'CNPJ',
+            'value'  => !empty($this->sanitizeNumber($customerInfo, 'customerCPF')) ? $this->sanitizeNumber($customerInfo, 'customerCPF') : $this->sanitizeNumber($customerInfo, 'customerCNPJ')
+        ];
+
+        $this->custumer['customer']['phone'] = [
+            'areaCode'  => substr($customerPhone, 0, 2),
+            'number'    => substr($customerPhone, 2)
+        ];
+
+        $this->validateCustomerInfo($this->custumer['customer']);
+
+        return $this;
+    }
+
+    /**
+     * Valida os dados contidos na array de informações do comprador.
+     *
+     * @param array $customerInfo
+     *
+     * @throws \Artistas\PagSeguro\PagSeguroException
+     */
+    private function validateCustomerInfo(array $customerInfo)
+    {
+
+        if($customerInfo['document']['type'] == "CPF")
+        {
+            $type = 'required|digits:11';
+        }
+        else
+        {
+            $type = 'required|digits:14';
+        }
+
+        $rules = [
+            'name'              => 'required|max:50',
+            'phone.areaCode'    => 'required|digits:2',
+            'phone.number'      => 'required|digits_between:8,9',
+            'email'             => 'required|email|max:60',
+            'document.value'    => $type,
+        ];
+
+        $this->validate($customerInfo, $rules);
+    }
+
+    /**
+     * Define os dados de endereço do comprador.
+     *
+     * @param array $customerAddress
+     *
+     * @return PagSeguroBoleto
+     *
+     * @throws \Artistas\PagSeguro\PagSeguroException
+     */
+    public function setCustomerAddress(array $customerAddress)
+    {
+        $this->custumer['address'] = [
+            'street'     => $this->sanitize($customerAddress, 'street'),
+            'number'     => $this->sanitize($customerAddress, 'number'),
+            'complement' => $this->sanitize($customerAddress, 'complement'),
+            'district'   => $this->sanitize($customerAddress, 'district'),
+            'postalCode' => $this->sanitizeNumber($customerAddress, 'postalCode'),
+            'city'       => $this->sanitize($customerAddress, 'city'),
+            'state'      => strtoupper($this->checkValue($customerAddress, 'state'))
+        ];
+
+        $this->validateCustomerAddress($this->custumer['address']);
+
+        return $this;
+    }
+
+    /**
+     *  Valida os dados contidos na array de endereço do comprador.
+     *
+     * @param array $customerAddress
+     *
+     * @throws \Artistas\PagSeguro\PagSeguroException
+     */
+    private function validateCustomerAddress(array $customerAddress)
+    {
+
+        $rules = [
+            'street'     => 'required|max:80',
+            'number'     => 'required|max:20',
+            'complement' => 'max:40',
+            'district'   => 'required|max:60',
+            'postalCode' => 'required|digits:8',
+            'city'       => 'required|min:2|max:60',
+            'state'      => 'required|min:2|max:2',
+        ];
+
+        $this->validate($customerAddress, $rules);
+    }
+
+    /**
+     * Define um id de referência da compra no pagseguro.
+     *
+     * @param string $reference
+     *
+     * @return $this
+     */
+    public function setReference($reference)
+    {
+        $this->reference = $this->sanitize($reference);
+
+        return $this;
+    }
+
+    /**
+     * Define o valor da compra no pagseguro.
+     *
+     * @param string $amount
+     *
+     * @return $this
+     */
+    public function setAmount($amount)
+    {
+        $this->amount = $this->sanitizeMoney($amount);
+
+        return $this;
+    }
+
+    /**
+     * Define o vendimento do boleto da compra no pagseguro.
+     *
+     * @param \Carbon\Carbon $firstDueDate
+     *
+     * @return $this
+     */
+    public function setFirstDueDate($firstDueDate)
+    {
+        $this->firstDueDate = $firstDueDate->format('Y-m-d');
+
+        return $this;
+    }
+
+    /**
+     * Define a quantidade de boletos gerados no pagseguro.
+     *
+     * @param string $numberOfPayments
+     *
+     * @return $this
+     */
+    public function setNumberOfPayments($numberOfPayments)
+    {
+        $this->numberOfPayments = $this->sanitizeNumber($numberOfPayments);
+
+        return $this;
+    }
+
+    /**
+     * Define a do item do boleto no pagseguro.
+     *
+     * @param string $description
+     *
+     * @return $this
+     */
+    public function setDescription($description)
+    {
+        $this->description = $this->sanitize($description);
+
+        return $this;
+    }
+
+    /**
+     * Define a instrução do boleto no pagseguro.
+     *
+     * @param string $instructions
+     *
+     * @return $this
+     */
+    public function setInstructions($instructions)
+    {
+        $this->instructions = $this->sanitize($instructions);
+
+        return $this;
+    }
+
+    /**
+     * Envia o boleto para o pagseguro.
+     *
+     * @return \SimpleXMLElement
+     * @throws \Artistas\PagSeguro\PagSeguroException
+     *
+     */
+    public function send()
+    {
+        if(empty($this->firstDueDate)){
+            self::setFirstDueDate(\Carbon\Carbon::now()->addDays(3));
+        }
+
+        if(empty($this->numberOfPayments)){
+            self::setNumberOfPayments(1);
+        }
+
+        $this->validatePaymentSettings();
+
+        $config = [
+            'reference'         => $this->reference,
+            'amount'            => $this->amount,
+            'notificationURL'   => $this->notificationURL,
+            'description'       => $this->description,
+            'instructions'      => $this->instructions,
+            'periodicity'       => 'monthly',
+            'numberOfPayments'  => $this->numberOfPayments,
+            'firstDueDate'      => $this->firstDueDate,
+        ];
+
+        $custumerArray = array_merge($this->custumer['customer'], ['address' => $this->custumer['address']]);
+
+        $data = array_filter(array_merge($config, ['customer' => $custumerArray]));
+
+        return $this->sendJsonTransaction($data, $this->url['boletos'], "POST", ['Accept: application/json;charset=ISO-8859-1', 'Content-type: application/json;charset=ISO-8859-1']);
+    }
+
+    /**
+     * Valida os dados de pagamento.
+     *
+     * @throws \Artistas\PagSeguro\PagSeguroException
+     */
+    private function validatePaymentSettings()
+    {
+        $this->validateCustomerInfo($this->custumer['customer']);
+        $this->validateCustomerAddress($this->custumer['address']);
+    }
+}

--- a/src/Artistas/PagSeguroBoletoFacade.php
+++ b/src/Artistas/PagSeguroBoletoFacade.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Artistas\PagSeguro;
+
+use Illuminate\Support\Facades\Facade;
+
+class PagSeguroBoletoFacade extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return 'pagseguro_boleto';
+    }
+}

--- a/src/Artistas/PagSeguroClient.php
+++ b/src/Artistas/PagSeguroClient.php
@@ -16,7 +16,7 @@ class PagSeguroClient extends PagSeguroConfig
      *
      * @return \SimpleXMLElement
      */
-    protected function sendTransaction(array $parameters, $url = null, $post = true, array $headers = null)
+    protected function sendTransaction(array $parameters, $url = null, $post = true, array $headers = ['Content-Type: application/x-www-form-urlencoded; charset=ISO-8859-1'])
     {
         if ($url === null) {
             $url = $this->url['transactions'];
@@ -38,7 +38,7 @@ class PagSeguroClient extends PagSeguroConfig
             $method = 'GET';
         }
 
-        $result = $this->executeCurl($parameters, $url, ['Content-Type: application/x-www-form-urlencoded; charset=ISO-8859-1'], $method);
+        $result = $this->executeCurl($parameters, $url, $headers, $method);
 
         return $this->formatResult($result);
     }
@@ -55,7 +55,7 @@ class PagSeguroClient extends PagSeguroConfig
      *
      * @return \SimpleXMLElement
      */
-    protected function sendJsonTransaction(array $parameters, $url = null, $method = 'POST', array $headers = null)
+    protected function sendJsonTransaction(array $parameters, $url = null, $method = 'POST', array $headers = ['Accept: application/vnd.pagseguro.com.br.v3+json;charset=ISO-8859-1', 'Content-Type: application/json; charset=UTF-8'])
     {
         if ($url === null) {
             $url = $this->url['transactions'];
@@ -73,7 +73,7 @@ class PagSeguroClient extends PagSeguroConfig
             $parameters = null;
         }
 
-        $result = $this->executeCurl($parameters, $url, ['Accept: application/vnd.pagseguro.com.br.v3+json;charset=ISO-8859-1', 'Content-Type: application/json; charset=UTF-8'], $method);
+        $result = $this->executeCurl($parameters, $url, $headers, $method);
 
         return $this->formatResultJson($result);
     }
@@ -82,10 +82,12 @@ class PagSeguroClient extends PagSeguroConfig
      * Executa o Curl.
      *
      * @param array|string $parameters
-     * @param string       $url
-     * @param array        $headers
+     * @param string $url
+     * @param array $headers
      *
+     * @param $method
      * @return \SimpleXMLElement
+     * @throws PagSeguroException
      */
     private function executeCurl($parameters, $url, array $headers, $method)
     {
@@ -200,6 +202,7 @@ class PagSeguroClient extends PagSeguroConfig
      * Inicia a Session do PagSeguro.
      *
      * @return string
+     * @throws PagSeguroException
      */
     public function startSession()
     {
@@ -214,7 +217,9 @@ class PagSeguroClient extends PagSeguroConfig
      *
      * @param string $notificationCode
      *
+     * @param string $notificationType
      * @return \SimpleXMLElement
+     * @throws PagSeguroException
      */
     public function notification($notificationCode, $notificationType = 'transaction')
     {

--- a/src/Artistas/PagSeguroConfig.php
+++ b/src/Artistas/PagSeguroConfig.php
@@ -96,6 +96,7 @@ class PagSeguroConfig
             'transactions'                  => 'https://ws.'.$sandbox.'pagseguro.uol.com.br/v2/transactions',
             'notifications'                 => 'https://ws.'.$sandbox.'pagseguro.uol.com.br/v3/transactions/notifications/',
             'javascript'                    => 'https://stc.'.$sandbox.'pagseguro.uol.com.br/pagseguro/api/v2/checkout/pagseguro.directpayment.js',
+            'boletos'                       => 'https://ws.pagseguro.uol.com.br/recurring-payment/boletos',
         ];
 
         $this->url = $url;

--- a/src/Artistas/PagSeguroServiceProvider.php
+++ b/src/Artistas/PagSeguroServiceProvider.php
@@ -15,6 +15,10 @@ class PagSeguroServiceProvider extends ServiceProvider
         $this->app->bind('pagseguro_recorrente', function ($app) {
             return new PagSeguroRecorrente($app['log'], $app['validator']);
         });
+
+        $this->app->bind('pagseguro_boleto', function ($app) {
+            return new PagSeguroBoleto($app['log'], $app['validator']);
+        });
     }
 
     public function boot()


### PR DESCRIPTION
```
$retorno = PagSeguroBoleto::setReference("Teste")
->setFirstDueDate(\Carbon\Carbon::now()->addDays(10))
->setAmount("10.50")
->setCustomerInfo([
	'name' => 'Nome do cliente',
	'phone' => '11987548631',
	'email' => 'teste@pagseguro.com.br',
	$clientTypeField => 62473932883
])
->setCustomerAddress([
	'street' => 'Rua Teste',
	'number' => '10',
	'district' => 'Centro',
	'postalCode' => '95000000',
	'city' => 'Cidade Teste',
	'state' => 'RS'
])
->setDescription("Testando o Boleto")
->setInstructions("Nao pagar é apenas um teste")
->setNumberOfPayments(1)
->send();
```